### PR TITLE
clarify convert for mixed, improve tests and bump version to 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoFormatTypes"
 uuid = "68eda718-8dee-11e9-39e7-89f7f65f511f"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
This PR improves choice of `convert` for mixed format types. Two types with `Mixed` mode defaults to converting geometries. `Mixed` is now the default if not specified in the constructor.

Tests are also improved.