### PR TITLE
Bugfixes

### DIFF
--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -95,7 +95,7 @@ mode(::Type{<:MixedFormat{M}}) where M = M()
 
 # Most GeoFormat types wrap String or have a constructor for string inputs
 Base.convert(::Type{String}, input::GeoFormat) = val(input)
-Base.convert(::Type{T}, input::AbstractString) where T <: GeoFormat = T(input)
+Base.convert(::Type{T}, input::AbstractString) where T <: GeoFormat = T(convert(String, (input))
 
 """
 Proj string
@@ -125,27 +125,27 @@ abstract type AbstractWellKnownText{X} <: MixedFormat{X} end
 """
 Well known text v1 following the OGC standard
 """
-struct WellKnownText{X,T<:String} <: AbstractWellKnownText{X}
+struct WellKnownText{X} <: AbstractWellKnownText{X}
     mode::X
-    val::T
+    val::String
 end
 WellKnownText(val) = WellKnownText(Mixed(), val)
 
 """
 Well known text v2 following the new OGC standard
 """
-struct WellKnownText2{X,T<:String} <: AbstractWellKnownText{X}
+struct WellKnownText2{X} <: AbstractWellKnownText{X}
     mode::X
-    val::T
+    val::String
 end
 WellKnownText2(val) = WellKnownText2(Mixed(), val)
 
 """
 Well known text following the ESRI standard
 """
-struct ESRIWellKnownText{X,T<:String} <: AbstractWellKnownText{X}
+struct ESRIWellKnownText{X} <: AbstractWellKnownText{X}
     mode::X
-    val::T
+    val::String
 end
 ESRIWellKnownText(val) = ESRIWellKnownText(Mixed(), val)
 
@@ -173,7 +173,7 @@ end
 """
 Constructor for "EPSG:1234" string input
 """
-EPSG(input::AbstractString) = begin
+function EPSG(input::AbstractString) = begin
     startswith(input, EPSG_PREFIX) || throw(ArgumentError("String $input does no start with $EPSG_PREFIX"))
     code = parse(Int, input[findlast(EPSG_PREFIX, input).stop+1:end])
     EPSG(code)
@@ -193,9 +193,9 @@ end
 """
 Geography Markup Language
 """
-struct GML{X,T<:String} <: MixedFormat{X}
+struct GML{X} <: MixedFormat{X}
     mode::X
-    val::T
+    val::String
 end
 GML(val) = GML(Mixed(), val)
 

--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -95,7 +95,7 @@ mode(::Type{<:MixedFormat{M}}) where M = M()
 
 # Most GeoFormat types wrap String or have a constructor for string inputs
 Base.convert(::Type{String}, input::GeoFormat) = val(input)
-Base.convert(::Type{T}, input::AbstractString) where T <: GeoFormat = T(convert(String, (input))
+Base.convert(::Type{T}, input::AbstractString) where T <: GeoFormat = T(convert(String, (input)))
 
 """
 Proj string
@@ -173,7 +173,7 @@ end
 """
 Constructor for "EPSG:1234" string input
 """
-function EPSG(input::AbstractString) = begin
+function EPSG(input::AbstractString)
     startswith(input, EPSG_PREFIX) || throw(ArgumentError("String $input does no start with $EPSG_PREFIX"))
     code = parse(Int, input[findlast(EPSG_PREFIX, input).stop+1:end])
     EPSG(code)
@@ -189,6 +189,7 @@ Keyhole Markup Language
 struct KML <: GeometryFormat
     val::String
 end
+convert(::Type{T}, ::KML) where T<:CoordinateReferenceSystemFormat = convert(T, EPSG(4326))
 
 """
 Geography Markup Language

--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -9,7 +9,7 @@ end GeoFormatTypes
 
 export GeoFormat
 
-export CoordinateReferenceSystemFormat, EPSG, ProjString, CoordSys
+export CoordinateReferenceSystemFormat, EPSG, ProjString, CoordSys, GML
 
 export GeometryFormat, GeoJSON, KML
 
@@ -138,7 +138,7 @@ struct WellKnownText2{X,T<:String} <: AbstractWellKnownText{X}
     mode::X
     val::T
 end
-WellKnownText2(val) = WellKnownText(Mixed(), val)
+WellKnownText2(val) = WellKnownText2(Mixed(), val)
 
 """
 Well known text following the ESRI standard
@@ -147,6 +147,7 @@ struct ESRIWellKnownText{X,T<:String} <: AbstractWellKnownText{X}
     mode::X
     val::T
 end
+ESRIWellKnownText(val) = ESRIWellKnownText(Mixed(), val)
 
 """
 Well known binary

--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -189,7 +189,8 @@ Keyhole Markup Language
 struct KML <: GeometryFormat
     val::String
 end
-convert(::Type{T}, ::KML) where T<:CoordinateReferenceSystemFormat = convert(T, EPSG(4326))
+# We know KML always has a crs of EPSG(4326)
+Base.convert(::Type{T}, ::KML) where T<:CoordinateReferenceSystemFormat = convert(T, EPSG(4326))
 
 """
 Geography Markup Language

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,27 @@ using GeoFormatTypes: Geom, CRS, Mixed
     @test EPSG("EPSG:4326") == EPSG(4326)
 end
 
+@testset "Test constructors" begin
+    @test ProjString("+proj=test") isa ProjString{String}
+    @test EPSG(4326) isa EPSG
+    @test WellKnownText("test") isa WellKnownText{Mixed,String}
+    @test WellKnownText2("test") isa WellKnownText2{Mixed,String}
+    @test ESRIWellKnownText("test") isa ESRIWellKnownText{Mixed,String}
+    @test GML("test") isa GML{Mixed}
+    @test GML(Geom(), "test") isa GML{Geom}
+    @test GML(CRS(), "test") isa GML{CRS} # Probably doesn't actually exist
+    @test KML("test") isa KML
+    @test GeoJSON("test") isa "test"
+end
+
+
 @testset "Test conversion to string or int" begin
     @test convert(String, ProjString("+proj=test")) == "+proj=test"
     @test convert(String, EPSG(4326)) == "EPSG:4326"
     @test convert(Int, EPSG(4326)) == 4326
     @test convert(String, WellKnownText("test")) == "test"
     @test convert(String, WellKnownText2("test")) == "test"
+    @test convert(String, ESRIWellKnownText("test")) == "test"
     @test convert(String, GML("test")) == "test"
     @test convert(String, KML("test")) == "test"
     @test convert(String, GeoJSON("test")) == "test"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,16 +8,16 @@ using GeoFormatTypes: Geom, CRS, Mixed
 end
 
 @testset "Test constructors" begin
-    @test ProjString("+proj=test") isa ProjString{String}
+    @test ProjString("+proj=test") isa ProjString
     @test EPSG(4326) isa EPSG
-    @test WellKnownText("test") isa WellKnownText{Mixed,String}
-    @test WellKnownText2("test") isa WellKnownText2{Mixed,String}
-    @test ESRIWellKnownText("test") isa ESRIWellKnownText{Mixed,String}
+    @test WellKnownText("test") isa WellKnownText{Mixed}
+    @test WellKnownText2("test") isa WellKnownText2{Mixed}
+    @test ESRIWellKnownText("test") isa ESRIWellKnownText{Mixed}
     @test GML("test") isa GML{Mixed}
     @test GML(Geom(), "test") isa GML{Geom}
     @test GML(CRS(), "test") isa GML{CRS} # Probably doesn't actually exist
     @test KML("test") isa KML
-    @test GeoJSON("test") isa "test"
+    @test GeoJSON("test") isa GeoJSON
 end
 
 


### PR DESCRIPTION
This PR adds more tests of the constructors, fixes some obvious bugs like adding an `ESRIWellKnownText` constructor and fixing the `WellKnownText2` constructor, and cleans up type parameters where `<:String` is unnecessarily a type parameter.