### PR TITLE
Accept multiple EPSG codes.

### DIFF
--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -164,7 +164,7 @@ struct ProjString <: CoordinateReferenceSystemFormat
     val::String
     ProjString(input::String) = begin
         startswith(input, PROJ_PREFIX) ||
-        throw(ArgumentError("Not a Proj string: $input does not start with $PROJ_PREFIX"))
+            throw(ArgumentError("Not a Proj string: $input does not start with $PROJ_PREFIX"))
         new(input)
     end
 end
@@ -181,12 +181,12 @@ struct ProjJSON <: CoordinateReferenceSystemFormat
     val::Union{String,Dict{String,<:Any}}
     ProjJSON(input::Dict{String,<:Any}) = begin
         haskey(input, "type") ||
-        throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
+            throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
         new(input)
     end
     ProjJSON(input::String) = begin
         occursin("type", input) ||
-        throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
+            throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
         new(input)
     end
 end

--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -164,7 +164,7 @@ struct ProjString <: CoordinateReferenceSystemFormat
     val::String
     ProjString(input::String) = begin
         startswith(input, PROJ_PREFIX) ||
-            throw(ArgumentError("Not a Proj string: $input does not start with $PROJ_PREFIX"))
+        throw(ArgumentError("Not a Proj string: $input does not start with $PROJ_PREFIX"))
         new(input)
     end
 end
@@ -181,12 +181,12 @@ struct ProjJSON <: CoordinateReferenceSystemFormat
     val::Union{String,Dict{String,<:Any}}
     ProjJSON(input::Dict{String,<:Any}) = begin
         haskey(input, "type") ||
-            throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
+        throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
         new(input)
     end
     ProjJSON(input::String) = begin
         occursin("type", input) ||
-            throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
+        throw(ArgumentError("Not a ProjJSON: $input does not have the required key 'type'"))
         new(input)
     end
 end
@@ -312,18 +312,21 @@ EPSG spatial reference system registry.
 String input must start with "$EPSG_PREFIX". `EPSG` can be converted to an `Int` or `String`
 using `convert`, or another `CoordinateReferenceSystemFormat` when ArchGDAL.jl is loaded.
 """
-struct EPSG <: CoordinateReferenceSystemFormat
-    val::Int
+struct EPSG{N} <: CoordinateReferenceSystemFormat
+    val::NTuple{N,Int}
 end
+EPSG(input::Vararg{Int}) = EPSG(input)
 function EPSG(input::AbstractString)
     startswith(input, EPSG_PREFIX) || throw(ArgumentError("String $input does no start with $EPSG_PREFIX"))
-    code = parse(Int, input[findlast(EPSG_PREFIX, input).stop+1:end])
+    code = Tuple(parse.(Int, split(input[findlast(EPSG_PREFIX, input).stop+1:end], "+")))
     EPSG(code)
 end
 
-Base.convert(::Type{Int}, input::EPSG) = val(input)
-Base.convert(::Type{String}, input::EPSG) = string(EPSG_PREFIX, val(input))
-Base.convert(::Type{EPSG}, input::Int) = EPSG(input)
+val(input::EPSG{1}) = input.val[1]  # backwards compatible
+Base.convert(::Type{Int}, input::EPSG{1}) = val(input)
+Base.convert(::Type{String}, input::EPSG) = string(EPSG_PREFIX, join(input.val, "+"))
+Base.convert(::Type{EPSG}, input::Int) = EPSG((input,))
+
 
 """
     KML <: GeometryFormat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using GeoFormatTypes: Geom, CRS, Extended, Unknown
     @test_throws ArgumentError ProjJSON("fype")
     @test_throws ArgumentError EPSG("ERROR:4326")
     @test EPSG("EPSG:4326") == EPSG(4326)
+    @test EPSG("EPSG:4326+3855") == EPSG((4326, 3855))
 end
 
 @testset "Test constructors" begin
@@ -14,6 +15,7 @@ end
     @test ProjJSON(Dict("type" => "GeographicCRS")) isa ProjJSON
     @test ProjJSON("type: GeographicCRS") isa ProjJSON
     @test EPSG(4326) isa EPSG
+    @test EPSG((4326, 3855)) isa EPSG
     @test WellKnownText("test") isa WellKnownText{Unknown}
     @test WellKnownBinary([1, 2, 3, 4]) isa WellKnownBinary{Unknown}
     @test WellKnownText2("test") isa WellKnownText2{Unknown}
@@ -33,6 +35,8 @@ end
     @test convert(String, ProjString("+proj=test")) == "+proj=test"
     @test convert(String, EPSG(4326)) == "EPSG:4326"
     @test convert(Int, EPSG(4326)) == 4326
+    @test_throws MethodError convert(Int, EPSG(4326, 3855))
+    @test convert(String, EPSG(4326, 3855)) == "EPSG:4326+3855"
     @test convert(String, WellKnownText("test")) == "test"
     @test convert(String, WellKnownText2("test")) == "test"
     @test convert(String, ESRIWellKnownText("test")) == "test"
@@ -41,6 +45,10 @@ end
     @test convert(String, GeoJSON("test")) == "test"
 end
 
+@testset "Test val" begin
+    @test GeoFormatTypes.val(EPSG(4326)) == 4326
+    @test GeoFormatTypes.val(EPSG(4326, 3855)) == (4326, 3855)
+end
 
 # `convert` placeholder methods
 Base.convert(target::Type{<:GeoFormat}, mode::Union{Geom,Type{Geom}}, source::GeoFormat; kwargs...) =


### PR DESCRIPTION
It's very common to supply codes like EPSG:4326+3855 for commandline tools like gdalwarp. It means, use a horizontal crs of WGS84 (4326) and a vertical crs of EGM2008 (3855).

However, one cannot construct such a compound crs from scratch easily in JuliaGeo, as one needs to construct a valid Proj4 string with an operation like `geoidgrids=grid.gtx`.

This PR introduces `N` dimensionality to the `EPSG` struct, so we can do `EPSG(4326, 3855)` but makes sure that for `EPSG{1}` the behaviour is backwards compatible. Methods like ArchGDAL call `val(::EPSG)`, and expect an `Int`, so using `EPSG{2}` will result in a MethodError.

Related to: https://github.com/yeesian/ArchGDAL.jl/pull/372, which introduces a method to actually parse EPSG:4326+3855 directly. After that and this PR are merged, we can introduce another PR at ArchGDAL to use the new method with `EPSG{2}`.