### PR TITLE
Implement CRSmode so we can dispatch on the type of crs.

### DIFF
--- a/src/GeoFormatTypes.jl
+++ b/src/GeoFormatTypes.jl
@@ -40,6 +40,16 @@ struct Geom <: FormatMode end
 Base.show(io::IO, ::MIME"text/plain", ::Type{Geom}) = print(io, "Geometry mode")
 
 """
+    CRSMode
+
+Traits to indicate the CRS type, such as `ProjectedCRS`, `GeographicCRS` or `UnknownCRS`.
+"""
+abstract type CRSMode end
+struct ProjectedCRS <: CRSMode end
+struct GeographicCRS <: CRSMode end
+struct UnknownCRS <: CRSMode end
+
+"""
     CRS <: FormatMode
 
     CRS()
@@ -47,8 +57,9 @@ Base.show(io::IO, ::MIME"text/plain", ::Type{Geom}) = print(io, "Geometry mode")
 Trait specifying that a format object, like [`WellKnownText`](@ref),
 contains only coordinate reference system data.
 """
-struct CRS <: FormatMode end
-Base.show(io::IO, ::MIME"text/plain", ::Type{CRS}) = print(io, "CRS mode")
+struct CRS{T<:CRSMode} <: FormatMode end
+CRS() = CRS{UnknownCRS}()
+Base.show(io::IO, ::MIME"text/plain", ::Type{CRS{T}}) where {T} = print(io, "$T mode")
 
 """
    MixedFormatMode <: FormatMode

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using GeoFormatTypes, Test
-using GeoFormatTypes: Geom, CRS, Extended, Unknown
+using GeoFormatTypes: Geom, CRS, Extended, Unknown, UnknownCRS
 
 @testset "Test construcors" begin
     @test_throws ArgumentError ProjString("+lat_ts=56.5 +ellps=GRS80")
@@ -23,11 +23,11 @@ end
     @test ESRIWellKnownText("test") isa ESRIWellKnownText{Unknown}
     @test WellKnownText(Extended(), "test") isa WellKnownText{Extended}
     @test WellKnownBinary(Extended(), [1, 2, 3, 4]) isa WellKnownBinary{Extended}
-    @test WellKnownText2(CRS(), "test") isa WellKnownText2{CRS}
+    @test WellKnownText2(CRS(), "test") isa WellKnownText2{CRS{UnknownCRS}}
     @test ESRIWellKnownText(Geom(), "test") isa ESRIWellKnownText{Geom}
     @test GML("test") isa GML{Unknown}
     @test GML(Geom(), "test") isa GML{Geom}
-    @test GML(CRS(), "test") isa GML{CRS} # Probably doesn't actually exist
+    @test GML(CRS(), "test") isa GML{CRS{UnknownCRS}}  # Probably doesn't actually exist
     @test KML("test") isa KML
     @test GeoJSON("test") isa GeoJSON
 end
@@ -125,11 +125,11 @@ Base.convert(target::Type{<:GeoFormat}, mode::Union{CRS,Type{CRS}}, source::GeoF
             (ESRIWellKnownText("test"), ("ESRIWellKnownText", "ESRIWellKnownText with Unknown mode: test")),
             (WellKnownText(Extended(), "test"), ("WellKnownText", "WellKnownText with Extended mode: test")),
             (WellKnownBinary(Extended(), [1, 2, 3, 4]), ("WellKnownBinary", "WellKnownBinary with Extended mode: [1, 2, 3, 4]")),
-            (WellKnownText2(CRS(), "test"), ("WellKnownText2", "WellKnownText2 with CRS mode: test")),
+            (WellKnownText2(CRS(), "test"), ("WellKnownText2", "WellKnownText2 with UnknownCRS mode: test")),
             (ESRIWellKnownText(Geom(), "test"), ("ESRIWellKnownText", "ESRIWellKnownText with Geometry mode: test")),
             (GML("test"), ("GML", "GML with Unknown mode: test")),
             (GML(Geom(), "test"), ("GML", "GML with Geometry mode: test")),
-            (GML(CRS(), "test"), ("GML", "GML with CRS mode: test")),
+            (GML(CRS(), "test"), ("GML", "GML with UnknownCRS mode: test")),
             (KML("test"), ("KML", "KML: test")),
             (GeoJSON("test"), ("GeoJSON String", "GeoJSON String: test")),
         ]


### PR DESCRIPTION
Partially solves #30.

As a follow up to https://github.com/JuliaGeo/GeoInterface.jl/pull/140. With this PR we can implement crstrait for GFT types, which can then be set and used across the ecosystem when reading crs information.